### PR TITLE
fix(installer): install .opencode runtime dependencies on fresh/migrate

### DIFF
--- a/PAI-Install/engine/steps-fresh.ts
+++ b/PAI-Install/engine/steps-fresh.ts
@@ -14,6 +14,7 @@ import type { ProviderName } from "./provider-models.ts";
 import { existsSync, mkdirSync, writeFileSync, chmodSync, symlinkSync, unlinkSync, lstatSync, realpathSync, readFileSync, renameSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { homedir } from "node:os";
+import { spawnSync } from "bun";
 
 // ═══════════════════════════════════════════════════════════
 // Step 1: Welcome
@@ -358,6 +359,30 @@ ${providerEnvVar}=${state.collected.apiKey || ""}
 		JSON.stringify(opencode, null, 2),
 	);
 	onProgress(96, "Generated opencode.json...");
+
+	// Install runtime dependencies needed by .opencode/tools scripts (e.g. yaml in switch-provider.ts)
+	onProgress(97, "Installing PAI runtime dependencies...");
+	const rootInstall = spawnSync({
+		cmd: ["bun", "install"],
+		cwd: installDir,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (rootInstall.exitCode !== 0) {
+		const err = rootInstall.stderr.toString().trim() || rootInstall.stdout.toString().trim();
+		throw new Error(`Failed to install repository dependencies: ${err}`);
+	}
+
+	const opencodeInstall = spawnSync({
+		cmd: ["bun", "install"],
+		cwd: localOpencodeDir,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (opencodeInstall.exitCode !== 0) {
+		const err = opencodeInstall.stderr.toString().trim() || opencodeInstall.stdout.toString().trim();
+		throw new Error(`Failed to install .opencode dependencies: ${err}`);
+	}
 
 	// Create symlink from ~/.opencode to local .opencode
 	onProgress(98, "Creating symlink ~/.opencode → ./.opencode...");

--- a/PAI-Install/engine/steps-migrate.ts
+++ b/PAI-Install/engine/steps-migrate.ts
@@ -8,6 +8,7 @@
 import { existsSync, cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { spawnSync } from "bun";
 import type { InstallState } from "./types";
 import { PAI_VERSION } from "./types";
 import { migrateV2ToV3, isMigrationNeeded } from "./migrate";
@@ -241,6 +242,23 @@ exec bun "${join(paiDir, "PAI", "Tools", "pai.ts")}" "$@"
 		writeFileSync(rcPath, content);
 	} catch (err) {
 		console.warn("Could not update shell rc file:", err);
+	}
+
+	// 4. Ensure runtime deps for .opencode/tools scripts are installed
+	onProgress(99, "Installing runtime dependencies...");
+	try {
+		const installResult = spawnSync({
+			cmd: ["bun", "install"],
+			cwd: paiDir,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		if (installResult.exitCode !== 0) {
+			const err = installResult.stderr.toString().trim() || installResult.stdout.toString().trim();
+			console.warn("Could not install .opencode dependencies:", err);
+		}
+	} catch (err) {
+		console.warn("Could not install runtime dependencies:", err);
 	}
 	
 	onProgress(100, "Migration complete!");


### PR DESCRIPTION
This is the follow-up fix after PR #101 merge for the runtime dependency gap seen on fresh machines.

Problem:
- pai startup path can execute .opencode/tools/switch-provider.ts
- That script imports yaml
- On fresh installs, .opencode/node_modules was not guaranteed to exist, causing: Cannot find package yaml

Changes:
- PAI-Install/engine/steps-fresh.ts
  - Run bun install in repo root
  - Run bun install in .opencode/
  - Fail install with explicit error if dependency install fails
- PAI-Install/engine/steps-migrate.ts
  - Run bun install in .opencode/ during migration finalization (best effort with warning)

Validation:
- bun run PAI-Install/cli/quick-install.ts --help

This ensures .opencode/tools scripts have required runtime packages on clean machines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Automatic runtime dependency installation now integrated into the fresh installation process with proper error handling
  * Dependency installation added to the migration workflow to ensure all required packages are available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->