### PR TITLE
Updating some model profiles

### DIFF
--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "@google/genai": "^1.38.0",
-    "@opencode-ai/plugin": "1.1.39",
+    "@opencode-ai/plugin": "1.2.15-feature/model-tiers-07c681eab",
     "ajv": "^8.17.1",
     "handlebars": "^4.7.8",
     "openai": "^6.16.0",

--- a/.opencode/plugins/lib/model-config.ts
+++ b/.opencode/plugins/lib/model-config.ts
@@ -12,10 +12,10 @@ import { fileLog } from "./file-logger";
  *
  * ZEN Free Models (as of Jan 2026):
  * - opencode/big-pickle (Free)
- * - opencode/grok-code (Free - Grok Code Fast 1)
- * - opencode/glm-4.7-free (Free - GLM 4.7)
- * - opencode/minimax-m2-1-free (Free - MiniMax M2.1)
- * - opencode/gpt-5-nano (Free)
+ * - opencode/nemotron-3-super-free (NVidia Nemotron 3 Super)
+ * - opencode/qwen3.6-plus-free (Qwen3.6 Plus Free)
+ * - opencode/mimo-v2-pro-free (MiMo V2 Pro Free)
+ * - opencode/mimo-v2-omni-free(MiMo V2 Omni Free)
  *
  * See: https://opencode.ai/docs/zen/
  */

--- a/.opencode/profiles/local.yaml
+++ b/.opencode/profiles/local.yaml
@@ -27,25 +27,25 @@ default_model: ollama/qwen3.5:9b
 # Agent routing with model tiers (CUSTOMIZE THESE!)
 agents:
   Algorithm:
-    model: ollama/qwen3.5:27b 
+    model: ollama/qwen3.5:27b
   Architect:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   Engineer:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   general:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   explore:
     model: ollama/qwen3.5:2b
   Intern:
@@ -65,31 +65,31 @@ agents:
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   GeminiResearcher:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   GrokResearcher:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   PerplexityResearcher:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   CodexResearcher:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   QATester:
     model: ollama/qwen3.5:9b
   Pentester:
@@ -97,16 +97,16 @@ agents:
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   Designer:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b
   Artist:
     model: ollama/qwen3.5:9b
     tiers:
       quick: ollama/qwen3.5:2b
       standard: ollama/qwen3.5:9b
-      advanced: ollama/qwen3.5:27b 
+      advanced: ollama/qwen3.5:27b

--- a/.opencode/profiles/local.yaml
+++ b/.opencode/profiles/local.yaml
@@ -8,104 +8,105 @@
 # To pull a model: ollama pull <model>
 #
 # Recommended models to pull:
-#   ollama pull qwen2.5-coder:32b    # Most capable coding model
-#   ollama pull qwen2.5-coder:7b     # Standard coding model
-#   ollama pull qwen2.5-coder:1.5b   # Fast budget model
+#   ollama pull qwen3.5:27b           # Most capable coding and general model
+#   ollama pull qwen3.5:9b            # Standard coding model
+#   ollama pull qwen3.5:2b            # Fast budget model
+#   ollama pull mistral-small3.2:24b  # Writing focused
 #
 # Alternative suggestions:
 #   ollama pull deepseek-coder-v2:latest  # Great for code
-#   ollama pull llama3.2:latest           # General purpose
-#   ollama pull codellama:latest          # Code-focused
+#   ollama pull gpt-oss:20b               # General purpose
+#   ollama pull qwen3.5:35b               # Code-focused
 #
 name: local
 description: Local Ollama models - offline/private, customize to your installed models
 
 # Default model for the main opencode.json "model" field
-default_model: ollama/qwen2.5-coder:7b
+default_model: ollama/qwen3.5:9b
 
 # Agent routing with model tiers (CUSTOMIZE THESE!)
 agents:
   Algorithm:
-    model: ollama/qwen2.5-coder:32b
+    model: ollama/qwen3.5:27b 
   Architect:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   Engineer:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   general:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   explore:
-    model: ollama/qwen2.5-coder:1.5b
+    model: ollama/qwen3.5:2b
   Intern:
-    model: ollama/qwen2.5-coder:1.5b
+    model: ollama/qwen3.5:2b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:1.5b
-      advanced: ollama/qwen2.5-coder:7b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:2b
+      advanced: ollama/qwen3.5:9b
   Writer:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/mistral-small3.2:24b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:9b
+      standard: ollama/mistral-small3.2:24b
+      advanced: ollama/mistral-small3.2:24b
   DeepResearcher:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   GeminiResearcher:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   GrokResearcher:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   PerplexityResearcher:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   CodexResearcher:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   QATester:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
   Pentester:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   Designer:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 
   Artist:
-    model: ollama/qwen2.5-coder:7b
+    model: ollama/qwen3.5:9b
     tiers:
-      quick: ollama/qwen2.5-coder:1.5b
-      standard: ollama/qwen2.5-coder:7b
-      advanced: ollama/qwen2.5-coder:32b
+      quick: ollama/qwen3.5:2b
+      standard: ollama/qwen3.5:9b
+      advanced: ollama/qwen3.5:27b 

--- a/.opencode/profiles/zen-paid.yaml
+++ b/.opencode/profiles/zen-paid.yaml
@@ -2,7 +2,7 @@
 # No subscription needed. PAID models preserve privacy (no data collection).
 #
 # Connect via: /connect in OpenCode → choose ZEN
-# Models: kimi-k2.5, glm-4.7, minimax-m2.1, gemini-3-flash
+# Models: kimi-k2.5, glm-5, minimax-m2.5, gemini-3-flash
 #
 name: zen-paid
 description: OpenCode ZEN paid models - budget-friendly, privacy-preserving
@@ -15,40 +15,40 @@ agents:
   Architect:
     model: opencode/kimi-k2.5
     tiers:
-      quick: opencode/glm-4.7
+      quick: opencode/glm-5
       standard: opencode/kimi-k2.5
       advanced: opencode/kimi-k2.5
   Engineer:
     model: opencode/kimi-k2.5
     tiers:
-      quick: opencode/glm-4.7
+      quick: opencode/glm-5
       standard: opencode/kimi-k2.5
       advanced: opencode/kimi-k2.5
   general:
-    model: opencode/glm-4.7
+    model: opencode/glm-5
     tiers:
-      quick: opencode/glm-4.7
+      quick: opencode/glm-5
       standard: opencode/kimi-k2.5
       advanced: opencode/kimi-k2.5
   explore:
-    model: opencode/minimax-m2.1
+    model: opencode/minimax-m2.5
   Intern:
-    model: opencode/minimax-m2.1
+    model: opencode/minimax-m2.5
     tiers:
-      quick: opencode/minimax-m2.1
-      standard: opencode/minimax-m2.1
-      advanced: opencode/glm-4.7
+      quick: opencode/minimax-m2.5
+      standard: opencode/minimax-m2.5
+      advanced: opencode/glm-5
   Writer:
     model: opencode/gemini-3-flash
     tiers:
-      quick: opencode/minimax-m2.1
+      quick: opencode/minimax-m2.5
       standard: opencode/gemini-3-flash
       advanced: opencode/kimi-k2.5
   DeepResearcher:
-    model: opencode/glm-4.7
+    model: opencode/glm-5
     tiers:
-      quick: opencode/minimax-m2.1
-      standard: opencode/glm-4.7
+      quick: opencode/minimax-m2.5
+      standard: opencode/glm-5
       advanced: opencode/kimi-k2.5
   GeminiResearcher:
     model: opencode/gemini-3-flash
@@ -59,38 +59,38 @@ agents:
   GrokResearcher:
     model: opencode/kimi-k2.5
     tiers:
-      quick: opencode/glm-4.7
+      quick: opencode/glm-5
       standard: opencode/kimi-k2.5
       advanced: opencode/kimi-k2.5
   PerplexityResearcher:
     model: opencode/kimi-k2.5
     tiers:
-      quick: opencode/glm-4.7
+      quick: opencode/glm-5
       standard: opencode/kimi-k2.5
       advanced: opencode/kimi-k2.5
   CodexResearcher:
-    model: opencode/glm-4.7
+    model: opencode/glm-5
     tiers:
-      quick: opencode/minimax-m2.1
-      standard: opencode/glm-4.7
+      quick: opencode/minimax-m2.5
+      standard: opencode/glm-5
       advanced: opencode/kimi-k2.5
   QATester:
-    model: opencode/glm-4.7
+    model: opencode/glm-5
   Pentester:
     model: opencode/kimi-k2.5
     tiers:
-      quick: opencode/glm-4.7
+      quick: opencode/glm-5
       standard: opencode/kimi-k2.5
       advanced: opencode/kimi-k2.5
   Designer:
-    model: opencode/glm-4.7
+    model: opencode/glm-5
     tiers:
-      quick: opencode/minimax-m2.1
-      standard: opencode/glm-4.7
+      quick: opencode/minimax-m2.5
+      standard: opencode/glm-5
       advanced: opencode/kimi-k2.5
   Artist:
-    model: opencode/glm-4.7
+    model: opencode/glm-5
     tiers:
-      quick: opencode/minimax-m2.1
-      standard: opencode/glm-4.7
+      quick: opencode/minimax-m2.5
+      standard: opencode/glm-5
       advanced: opencode/kimi-k2.5

--- a/.opencode/profiles/zen.yaml
+++ b/.opencode/profiles/zen.yaml
@@ -7,90 +7,90 @@
 name: zen-free
 description: OpenCode ZEN free models - no API key needed, great for getting started
 
-default_model: opencode/kimi-k2.5-free
+default_model: opencode/qwen3.6-plus-free
 
 agents:
   Algorithm:
-    model: opencode/big-pickle
+    model: opencode/nemotron-3-super-free
   Architect:
-    model: opencode/kimi-k2.5-free
+    model: opencode/qwen3.6-plus-free
     tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/kimi-k2.5-free
-      advanced: opencode/big-pickle
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/qwen3.6-plus-free
+      advanced: opencode/mimo-v2-pro-free
   Engineer:
-    model: opencode/kimi-k2.5-free
+    model: opencode/qwen3.6-plus-free
     tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/kimi-k2.5-free
-      advanced: opencode/big-pickle
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/qwen3.6-plus-free
+      advanced: opencode/mimo-v2-pro-free
   general:
-    model: opencode/kimi-k2.5-free
+    model: opencode/qwen3.6-plus-free
     tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/kimi-k2.5-free
-      advanced: opencode/big-pickle
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/qwen3.6-plus-free
+      advanced: opencode/mimo-v2-pro-free
   explore:
-    model: opencode/gpt-5-nano
+    model: opencode/mimo-v2-pro-free
   Intern:
-    model: opencode/gpt-5-nano
-    tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/gpt-5-nano
-      advanced: opencode/kimi-k2.5-free
-  Writer:
-    model: opencode/kimi-k2.5-free
-    tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/kimi-k2.5-free
-      advanced: opencode/big-pickle
-  DeepResearcher:
-    model: opencode/glm-4.7-free
-    tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/glm-4.7-free
-      advanced: opencode/kimi-k2.5-free
-  GeminiResearcher:
-    model: opencode/minimax-m2.1-free
-    tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/minimax-m2.1-free
-      advanced: opencode/kimi-k2.5-free
-  GrokResearcher:
-    model: opencode/kimi-k2.5-free
-    tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/kimi-k2.5-free
-      advanced: opencode/big-pickle
-  PerplexityResearcher:
     model: opencode/big-pickle
     tiers:
-      quick: opencode/gpt-5-nano
+      quick: opencode/big-pickle
       standard: opencode/big-pickle
-      advanced: opencode/big-pickle
+      advanced: opencode/qwen3.6-plus-free
+  Writer:
+    model: opencode/qwen3.6-plus-free
+    tiers:
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/qwen3.6-plus-free
+      advanced: opencode/mimo-v2-pro-free
+  DeepResearcher:
+    model: opencode/minimax-m2.5-free
+    tiers:
+      quick: opencode/mimo-v2-pro-free
+      standard: opencode/minimax-m2.5-free
+      advanced: opencode/qwen3.6-plus-free
+  GeminiResearcher:
+    model: opencode/minimax-m2.5-free
+    tiers:
+      quick: opencode/big-pickle
+      standard: opencode/minimax-m2.5-free
+      advanced: opencode/qwen3.6-plus-free
+  GrokResearcher:
+    model: opencode/qwen3.6-plus-free
+    tiers:
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/qwen3.6-plus-free
+      advanced: opencode/mimo-v2-pro-free
+  PerplexityResearcher:
+    model: opencode/nemotron-3-super-free
+    tiers:
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/nemotron-3-super-free
+      advanced: opencode/mimo-v2-pro-free
   CodexResearcher:
-    model: opencode/glm-4.7-free
+    model: opencode/mimo-v2-pro-free
     tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/glm-4.7-free
-      advanced: opencode/kimi-k2.5-free
+      quick: opencode/minimax-m2.5-free
+      standard: opencode/mimo-v2-pro-free
+      advanced: opencode/qwen3.6-plus-free
   QATester:
-    model: opencode/kimi-k2.5-free
+    model: opencode/qwen3.6-plus-free
   Pentester:
-    model: opencode/kimi-k2.5-free
+    model: opencode/qwen3.6-plus-free
     tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/kimi-k2.5-free
-      advanced: opencode/big-pickle
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/nemotron-3-super-free
+      advanced: opencode/mimo-v2-pro-free
   Designer:
-    model: opencode/kimi-k2.5-free
+    model: opencode/qwen3.6-plus-free
     tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/kimi-k2.5-free
-      advanced: opencode/big-pickle
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/nemotron-3-super-free
+      advanced: opencode/mimo-v2-pro-free
   Artist:
-    model: opencode/kimi-k2.5-free
+    model: opencode/qwen3.6-plus-free
     tiers:
-      quick: opencode/gpt-5-nano
-      standard: opencode/kimi-k2.5-free
-      advanced: opencode/big-pickle
+      quick: opencode/nemotron-3-super-free
+      standard: opencode/nemotron-3-super-free
+      advanced: opencode/mimo-v2-pro-free


### PR DESCRIPTION
- OpenCode has deprecated a number of models and added others.  (e.g. minimax-2.1 is no longer available)
- Opencode free has swapped out nearly everything but Big Pickle
- There are more capable Qwen models at same or lower VRAM usage with the new 3.5 versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default models and tier mappings across local, free (ZEN), and paid profiles so agents use newer model variants for improved baseline and tiered behavior.
  * Updated plugin reference to a newer build/version.

* **Documentation**
  * Revised the listed available free models and recommended alternatives shown to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->