### PR TITLE
fix(banner): PAI-OpenCode v3.0 branding — replace vanilla PAI 4.0.3 defaults

### DIFF
--- a/.opencode/PAI/Tools/Banner.ts
+++ b/.opencode/PAI/Tools/Banner.ts
@@ -113,14 +113,14 @@ interface SystemStats {
 
 function getStats(): SystemStats {
   let name = "PAI";
-  let paiVersion = "4.0.3";
+  let paiVersion = "3.0.0";                                   // PAI-OpenCode version
   let algorithmVersion = "3.7.0";
   let catchphrase = "{name} here, ready to go";
-  let repoUrl = "github.com/danielmiessler/PAI";
+  let repoUrl = "github.com/Steffen025/pai-opencode";         // PAI-OpenCode repo
   try {
     const settings = JSON.parse(readFileSync(join(CLAUDE_DIR, "settings.json"), "utf-8"));
     name = settings.daidentity?.displayName || settings.daidentity?.name || "PAI";
-    paiVersion = settings.pai?.version || "2.0";
+    paiVersion = settings.pai?.version || "3.0.0";
     algorithmVersion = (settings.pai?.algorithmVersion || algorithmVersion).replace(/^v/i, '');
     catchphrase = settings.daidentity?.startupCatchphrase || catchphrase;
     repoUrl = settings.pai?.repoUrl || repoUrl;
@@ -163,10 +163,10 @@ function getStats(): SystemStats {
   const platform = process.platform === "darwin" ? "macOS" : process.platform;
   const arch = process.arch;
 
-  // Try to get Claude Code version
-  let ccVersion = "2.0";
+  // Try to get OpenCode version
+  let ccVersion = "";
   try {
-    const result = spawnSync("claude", ["--version"], { encoding: "utf-8" });
+    const result = spawnSync("opencode", ["--version"], { encoding: "utf-8" });
     if (result.stdout) {
       const match = result.stdout.match(/(\d+\.\d+\.\d+)/);
       if (match) ccVersion = match[1];
@@ -325,10 +325,10 @@ function createNavyBanner(stats: SystemStats, width: number): string {
   lines.push(`${framePad}${topBorder}`);
   lines.push("");
 
-  // Header: PAI (in logo colors) | Personal AI Infrastructure
+  // Header: PAI-OpenCode v3.0 | Personal AI Infrastructure
   const paiColored = `${C.navy}P${RESET}${C.medBlue}A${RESET}${C.lightBlue}I${RESET}`;
-  const headerText = `${paiColored} ${C.steel}|${RESET} ${C.slate}Personal AI Infrastructure${RESET}`;
-  const headerLen = 33; // "PAI | Personal AI Infrastructure"
+  const headerText = `${paiColored}${C.slate}-OpenCode ${C.silver}v${stats.paiVersion}${RESET} ${C.steel}|${RESET} ${C.slate}Personal AI Infrastructure${RESET}`;
+  const headerLen = 44; // "PAI-OpenCode v3.0.0 | Personal AI Infrastructure"
   const headerPad = " ".repeat(Math.floor((width - headerLen) / 2));
   lines.push(`${headerPad}${headerText}`);
   lines.push(""); // Blank line between header and tagline
@@ -355,11 +355,16 @@ function createNavyBanner(stats: SystemStats, width: number): string {
   lines.push("");
   lines.push("");
 
-  // Footer: Unicode symbol + URL in medium blue (A color)
+  // Footer: repo URL + credit line
   const urlLine = `${C.steel}\u2192${RESET} ${C.medBlue}${stats.repoUrl}${RESET}`;
   const urlLen = stats.repoUrl.length + 3;
   const urlPad = " ".repeat(Math.floor((width - urlLen) / 2));
   lines.push(`${urlPad}${urlLine}`);
+
+  const creditLine = `${C.muted}Built on PAI by Daniel Miessler \u00b7 github.com/danielmiessler/PAI${RESET}`;
+  const creditLen = 61; // visible length
+  const creditPad = " ".repeat(Math.floor((width - creditLen) / 2));
+  lines.push(`${creditPad}${creditLine}`);
   lines.push("");
 
   // Bottom border with full horizontal line and reticle corners
@@ -675,8 +680,8 @@ function createNavyMediumBanner(stats: SystemStats, width: number): string {
 
   // Header (no border)
   const paiColored = `${C.navy}P${RESET}${C.medBlue}A${RESET}${C.lightBlue}I${RESET}`;
-  const headerText = `${paiColored} ${C.steel}|${RESET} ${C.slate}Personal AI Infrastructure${RESET}`;
-  const headerPad = " ".repeat(Math.max(0, Math.floor((width - 33) / 2)));
+  const headerText = `${paiColored}${C.slate}-OpenCode ${C.silver}v${stats.paiVersion}${RESET} ${C.steel}|${RESET} ${C.slate}Personal AI Infrastructure${RESET}`;
+  const headerPad = " ".repeat(Math.max(0, Math.floor((width - 44) / 2)));
   lines.push(`${headerPad}${headerText}`);
   lines.push("");
 
@@ -697,6 +702,9 @@ function createNavyMediumBanner(stats: SystemStats, width: number): string {
   const urlLine = `${C.steel}\u2192${RESET} ${C.medBlue}${stats.repoUrl}${RESET}`;
   const urlPad = " ".repeat(Math.max(0, Math.floor((width - stats.repoUrl.length - 3) / 2)));
   lines.push(`${urlPad}${urlLine}`);
+  const creditLine = `${C.steel}Built on PAI by Daniel Miessler \u00b7 github.com/danielmiessler/PAI${RESET}`;
+  const creditPad = " ".repeat(Math.max(0, Math.floor((width - 61) / 2)));
+  lines.push(`${creditPad}${creditLine}`);
   lines.push("");
 
   return lines.join("\n");


### PR DESCRIPTION
## Summary

When users type `pai`, the startup banner was showing vanilla PAI branding (v4.0.3, Daniel Miessler's repo URL) instead of PAI-OpenCode identifiers.

## Changes (`Banner.ts`)

| Before | After |
|--------|-------|
| `paiVersion = "4.0.3"` (hardcoded default) | `paiVersion = "3.0.0"` |
| `repoUrl = "github.com/danielmiessler/PAI"` | `repoUrl = "github.com/Steffen025/pai-opencode"` |
| `settings.pai?.version \|\| "2.0"` | `settings.pai?.version \|\| "3.0.0"` |
| Header: `PAI \| Personal AI Infrastructure` | Header: `PAI-OpenCode v3.0.0 \| Personal AI Infrastructure` |
| No credit line | Credit: `Built on PAI by Daniel Miessler · github.com/danielmiessler/PAI` |
| `claude --version` for version detection | `opencode --version` |

## Result

- Large + medium banners now show **PAI-OpenCode v3.0.0** in the header
- Footer URL points to **this repo** (`github.com/Steffen025/pai-opencode`)
- Credit line gives proper attribution to Daniel Miessler and links to upstream PAI
- Version detection no longer calls the non-existent `claude` binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated banner branding to display "PAI-OpenCode" with dynamic version information.
  * Added attribution credit line to banner footer.
  * Refreshed version defaults and tool detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->