### PR TITLE
fix: hero banner path in README broken after v2.0 image deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![PAI-OpenCode Hero Banner](docs/images/v2.0-hero-banner.jpg)
+![PAI-OpenCode Hero Banner](docs/images/hero-banner.jpg)
 
 # PAI-OpenCode
 


### PR DESCRIPTION
README still referenced `docs/images/v2.0-hero-banner.jpg` which was deleted. Updated to `docs/images/hero-banner.jpg`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README banner image

<!-- end of auto-generated comment: release notes by coderabbit.ai -->