### PR TITLE
fix(migration): add missing closing brace in migrateSkills function

### DIFF
--- a/Tools/migration-v2-to-v3.ts
+++ b/Tools/migration-v2-to-v3.ts
@@ -246,7 +246,8 @@ async function migrateSkills(report: MigrationReport, dryRun: boolean): Promise<
 				log(`Migrated flat skill to hierarchical: ${skill.name}`, "success");
 				migratedCount++;
 			}
-		} // Close SKILL.md check
+		} // Close if (dryRun)
+	} // Close SKILL.md check
 	}
 
 	if (migratedCount > 0) {


### PR DESCRIPTION
## Summary

- Fixes TypeScript syntax error in `Tools/migration-v2-to-v3.ts` that blocked CodeQL JavaScript/TypeScript scan
- `if (skillFiles.includes('SKILL.md'))` block at L207 was never closed — the `}` at L249 closed the inner `if (dryRun)/else` block but the SKILL.md check remained open
- Added the missing `}` between L249 and L250

## Root Cause

Mixed indentation + misleading comment masked the brace mismatch. Brace count across `migrateSkills()` was off by one (net: 1 instead of 0).

## Verification

`bun run Tools/migration-v2-to-v3.ts --dry-run --force` completes fully without parse errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code structure and clarity in the migration tool through reorganization of control flow comments and brace associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->